### PR TITLE
Add Securty group submodule

### DIFF
--- a/modules/sg_rule/README.md
+++ b/modules/sg_rule/README.md
@@ -1,0 +1,32 @@
+# Terraform submodule to create security groups rules.
+
+This module is usable externally.
+
+You can use this submodule to create Security Group rules easily.
+The idea is that you can create ingress or egress rule for one
+protocol, but for multiple CIDR subnets and ports.
+
+This submodule is too small to be a separate module, and SG rules
+are part of VPC, hence I added this as a submodule here.
+
+Example usage:
+
+```
+resource "aws_security_group" "in" {
+  vpc_id = "<vpc.id>"
+}
+
+module "ingress_rules" {
+  source = "github.com/invizus/terraform-aws-vpc/modules/sg_rule"
+  type = "ingress"
+  ports = [
+    22
+  ]
+  protocol = "tcp"
+  cidr_blocks = [
+    "0.0.0.0/0"
+  ]
+  id = aws_security_group.in.id
+}
+```
+

--- a/modules/sg_rule/main.tf
+++ b/modules/sg_rule/main.tf
@@ -1,0 +1,10 @@
+resource "aws_security_group_rule" "rule" {
+  type              = var.type
+  for_each          = { for port in var.ports : port => port }
+  from_port         = each.key
+  to_port           = each.key
+  protocol          = var.protocol
+  cidr_blocks       = var.cidr_blocks
+  security_group_id = var.id
+}
+

--- a/modules/sg_rule/variables.tf
+++ b/modules/sg_rule/variables.tf
@@ -1,0 +1,26 @@
+variable "type" {
+  description = "The flow of traffic, ingress or egress."
+  type        = list(string)
+}
+
+variable "ports" {
+  description = "List of ports to allow."
+  type        = list(number)
+}
+
+variable "protocol" {
+  description = "Protocol udp or tcp. Defaults to tcp."
+  type        = list(string)
+  default     = "tcp"
+}
+
+variable "cidr_blocks" {
+  description = "List of CIDR blocks to allow."
+  type        = list(string)
+}
+
+variable "id" {
+  description = "id of a security group to attach the rules to."
+  type        = string
+}
+


### PR DESCRIPTION
This PR will add a submodule that can be used to create security group rules easily, and attach them to the security group that you create yourself.